### PR TITLE
feat: domain entity 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+	runtimeOnly 'org.postgresql:postgresql'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'

--- a/src/main/java/ojik/ojikback/domain/Attendance.java
+++ b/src/main/java/ojik/ojikback/domain/Attendance.java
@@ -1,0 +1,61 @@
+package ojik.ojikback.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import ojik.ojikback.domain.enums.AttendanceStatus;
+
+@Entity
+@Table(
+        name = "attendances",
+        uniqueConstraints = @UniqueConstraint(name = "uk_attendance_member_game", columnNames = {"member_id", "game_id"})
+)
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Attendance {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "game_id", nullable = false)
+    private Game game;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "stadium_id", nullable = false)
+    private Stadium stadium;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private AttendanceStatus status;
+
+    @Column(name = "certified_at", nullable = false)
+    private LocalDateTime certifiedAt;
+
+    @Column(nullable = false, precision = 10, scale = 7)
+    private BigDecimal latitude;
+
+    @Column(nullable = false, precision = 10, scale = 7)
+    private BigDecimal longitude;
+}

--- a/src/main/java/ojik/ojikback/domain/ChatMessage.java
+++ b/src/main/java/ojik/ojikback/domain/ChatMessage.java
@@ -1,0 +1,44 @@
+package ojik.ojikback.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Lob;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "chat_messages")
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChatMessage {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "chat_room_id", nullable = false)
+    private TeamChatRoom chatRoom;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Lob
+    @Column(nullable = false)
+    private String content;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/ojik/ojikback/domain/Diary.java
+++ b/src/main/java/ojik/ojikback/domain/Diary.java
@@ -1,0 +1,75 @@
+package ojik.ojikback.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Lob;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "diary")
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Diary {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "game_id")
+    private Game game;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "attendance_id")
+    private Attendance attendance;
+
+    @Column(name = "is_certified", nullable = false)
+    private boolean certified;
+
+    @Column(name = "game_date", nullable = false)
+    private LocalDate gameDate;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "support_team_id", nullable = false)
+    private Team supportTeam;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "opponent_team_id", nullable = false)
+    private Team opponentTeam;
+
+    @Column(name = "stadium_name", nullable = false, length = 100)
+    private String stadiumName;
+
+    @Column(name = "seat_section", length = 30)
+    private String seatSection;
+
+    @Column(name = "seat_row", length = 30)
+    private String seatRow;
+
+    @Column(name = "seat_number", length = 30)
+    private String seatNumber;
+
+    @Lob
+    @Column(name = "diary_content")
+    private String diaryContent;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/ojik/ojikback/domain/DiaryPhoto.java
+++ b/src/main/java/ojik/ojikback/domain/DiaryPhoto.java
@@ -1,0 +1,38 @@
+package ojik.ojikback.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "diary_photos")
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DiaryPhoto {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "game_record_id", nullable = false)
+    private Diary diary;
+
+    @Column(name = "photo_url", nullable = false, length = 255)
+    private String photoUrl;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/ojik/ojikback/domain/Game.java
+++ b/src/main/java/ojik/ojikback/domain/Game.java
@@ -1,0 +1,56 @@
+package ojik.ojikback.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDate;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import ojik.ojikback.domain.enums.GameStatus;
+
+@Entity
+@Table(name = "games")
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Game {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "game_date", nullable = false)
+    private LocalDate gameDate;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "home_team_id", nullable = false)
+    private Team homeTeam;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "away_team_id", nullable = false)
+    private Team awayTeam;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "stadium_id", nullable = false)
+    private Stadium stadium;
+
+    @Column(name = "home_score")
+    private Integer homeScore;
+
+    @Column(name = "away_score")
+    private Integer awayScore;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private GameStatus status;
+}

--- a/src/main/java/ojik/ojikback/domain/Member.java
+++ b/src/main/java/ojik/ojikback/domain/Member.java
@@ -1,0 +1,50 @@
+package ojik.ojikback.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "members")
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Member {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 50)
+    private String nickname;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "favorite_team_id", nullable = false)
+    private Team favoriteTeam;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    @OneToMany(mappedBy = "member")
+    private List<SocialAccount> socialAccounts = new ArrayList<>();
+}

--- a/src/main/java/ojik/ojikback/domain/SocialAccount.java
+++ b/src/main/java/ojik/ojikback/domain/SocialAccount.java
@@ -1,0 +1,49 @@
+package ojik.ojikback.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import ojik.ojikback.domain.enums.SocialProvider;
+
+@Entity
+@Table(
+        name = "social_accounts",
+        uniqueConstraints = @UniqueConstraint(name = "uk_social_provider_user", columnNames = {"provider", "provider_user_id"})
+)
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SocialAccount {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private SocialProvider provider;
+
+    @Column(name = "provider_user_id", nullable = false, length = 50)
+    private String providerUserId;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/ojik/ojikback/domain/Stadium.java
+++ b/src/main/java/ojik/ojikback/domain/Stadium.java
@@ -1,0 +1,37 @@
+package ojik.ojikback.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "stadiums")
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Stadium {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 100)
+    private String name;
+
+    @Column(nullable = false, length = 50)
+    private String city;
+
+    @Column(nullable = false, precision = 10, scale = 7)
+    private BigDecimal latitude;
+
+    @Column(nullable = false, precision = 10, scale = 7)
+    private BigDecimal longitude;
+}

--- a/src/main/java/ojik/ojikback/domain/Team.java
+++ b/src/main/java/ojik/ojikback/domain/Team.java
@@ -1,0 +1,33 @@
+package ojik.ojikback.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "teams")
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Team {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 50)
+    private String name;
+
+    @Column(name = "short_name", nullable = false, length = 50)
+    private String shortName;
+
+    @Column(name = "theme_color", nullable = false, length = 50)
+    private String themeColor;
+}

--- a/src/main/java/ojik/ojikback/domain/TeamChatRoom.java
+++ b/src/main/java/ojik/ojikback/domain/TeamChatRoom.java
@@ -1,0 +1,39 @@
+package ojik.ojikback.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(
+        name = "team_chat_rooms",
+        uniqueConstraints = @UniqueConstraint(name = "uk_team_chat_room_team", columnNames = "team_id")
+)
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TeamChatRoom {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "team_id", nullable = false)
+    private Team team;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/ojik/ojikback/domain/enums/AttendanceStatus.java
+++ b/src/main/java/ojik/ojikback/domain/enums/AttendanceStatus.java
@@ -1,0 +1,6 @@
+package ojik.ojikback.domain.enums;
+
+public enum AttendanceStatus {
+    CERTIFIED,
+    REVOKED
+}

--- a/src/main/java/ojik/ojikback/domain/enums/GameStatus.java
+++ b/src/main/java/ojik/ojikback/domain/enums/GameStatus.java
@@ -1,0 +1,6 @@
+package ojik.ojikback.domain.enums;
+
+public enum GameStatus {
+    SCHEDULED,
+    FINISHED
+}

--- a/src/main/java/ojik/ojikback/domain/enums/SocialProvider.java
+++ b/src/main/java/ojik/ojikback/domain/enums/SocialProvider.java
@@ -1,0 +1,6 @@
+package ojik.ojikback.domain.enums;
+
+public enum SocialProvider {
+    KAKAO,
+    NAVER
+}

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -1,0 +1,13 @@
+spring:
+  datasource:
+    url: jdbc:postgresql://localhost:5432/ojik
+    username: ${DB_USERNAME:ojik}
+    password: ${DB_PASSWORD:ojik}
+    driver-class-name: org.postgresql.Driver
+  jpa:
+    hibernate:
+      ddl-auto: create
+    open-in-view: false
+    properties:
+      hibernate:
+        format_sql: true

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -1,0 +1,10 @@
+spring:
+  datasource:
+    url: ${DB_URL}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+    driver-class-name: org.postgresql.Driver
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    open-in-view: false

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,3 +1,5 @@
 spring:
   application:
     name: ojikback
+  profiles:
+    default: local


### PR DESCRIPTION
**Summary**
 - 도메인 엔티티 구성 및 환경별 application.yaml DB/JPA 설정 추가

**Changes**
  - Member, Team, Stadium, Game, Attendance, Diary, DiaryPhoto, SocialAccount, TeamChatRoom, ChatMessage 엔티티 추가
  - 엔티티 간 연관관계 및 제약조건 설정
  - application-local.yaml/application-prod.yaml에 datasource 및 JPA 설정 구성
